### PR TITLE
add missing slash when `XDG_DATA_HOME` is set

### DIFF
--- a/lsfg-vk-gen/src/lsfg.cpp
+++ b/lsfg-vk-gen/src/lsfg.cpp
@@ -32,7 +32,7 @@ void LSFG::initialize() {
         const char* dataDir = getenv("XDG_DATA_HOME");
         if (dataDir && *dataDir != '\0') {
             dllPathStr = std::string(dataDir) +
-                "Steam/steamapps/common/Lossless Scaling/Lossless.dll";
+                "/Steam/steamapps/common/Lossless Scaling/Lossless.dll";
         } else {
             const char* homeDir = getenv("HOME");
             if (homeDir && *homeDir != '\0') {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/08d58ece-74c5-406d-a2ca-ac0e1cd03c2f)
