### PR TITLE
fix build error error: no member named 'copy_n' in namespace 'std' in…

### DIFF
--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -6,6 +6,7 @@
 
 #include <lsfg.hpp>
 
+#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <vulkan/vulkan_core.h>


### PR DESCRIPTION
… hooks.cpp on ubuntu-24.04-based system

Wouldn't build on my system without.