### PR TITLE
install.sh: NixOS option and various improvements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 : "${INSTALL_PATH:=$HOME/.local}"
 BASE_URL='https://pancake.gay/lsfg-vk'
+NIX_FLAKE_REPO='https://github.com/pabloaul/lsfg-vk-flake'
 
 # prompt for distro
 echo "Which version would you like to install?"
@@ -9,7 +10,8 @@ echo "1) Arch Linux (Artix Linux, CachyOS, Steam Deck, etc.)"
 echo "2) Debian"
 echo "3) Ubuntu"
 echo "4) Fedora"
-printf "Enter the number (1-4): "
+echo "5) NixOS (external flake project)"
+printf "Enter the number (1-5): "
 read -r version_choice < /dev/tty
 
 case "$version_choice" in
@@ -17,6 +19,7 @@ case "$version_choice" in
     2) DISTRO="debian"; DISTRO_PRETTY="Debian" ;;
     3) DISTRO="ubuntu"; DISTRO_PRETTY="Ubuntu" ;;
     4) DISTRO="fedora"; DISTRO_PRETTY="Fedora" ;;
+    5) DISTRO="nixos"; DISTRO_PRETTY="NixOS"; USE_NIX=true ;;
     *) echo "Invalid choice."; exit 1 ;;
 esac
 
@@ -25,12 +28,18 @@ SHA_NAME="lsfg-vk_${DISTRO}.zip.sha"
 SHA_FILE="$INSTALL_PATH/share/lsfg-vk.sha"
 
 # get local and remote versions
-REMOTE_HASH=$(curl -fsSL "$BASE_URL/$SHA_NAME")
 LOCAL_HASH=$(test -f "$SHA_FILE" && cat "$SHA_FILE")
+if [ "$USE_NIX" ]; then
+    command -v nix >/dev/null 2>&1 || { echo "Error: nix command not found."; exit 1; }
+    REMOTE_HASH=$(curl -fsSL "${NIX_FLAKE_REPO/github.com/api.github.com/repos}/releases/latest" | grep '"tag_name"' | cut -d '"' -f 4)
+else
+    REMOTE_HASH=$(curl -fsSL "$BASE_URL/$SHA_NAME")
+fi
+[ -z "$REMOTE_HASH" ] && { echo "Failed to fetch latest release."; exit 1; }
 
 if [ "$REMOTE_HASH" != "$LOCAL_HASH" ]; then
     # prompt user for confirmation
-    echo -n "Are you sure you want to install lsfg-vk for ${DISTRO_PRETTY}? (y/n) "
+    echo -n "Are you sure you want to install lsfg-vk ($REMOTE_HASH) for ${DISTRO_PRETTY}? (y/n) "
     read -r answer < /dev/tty
 
     if [ "$answer" != "y" ]; then
@@ -38,18 +47,24 @@ if [ "$REMOTE_HASH" != "$LOCAL_HASH" ]; then
         exit 0
     fi
 
-    # download lsfg-vk
-    curl -fsSL -o "/tmp/$ZIP_NAME" "$BASE_URL/$ZIP_NAME"
-    if [ $? -ne 0 ]; then
-        echo "Failed to download lsfg-vk. Please check your internet connection."
-        exit 1
-    fi
+    TEMP_DIR=$(mktemp -d) && cd "$TEMP_DIR" || { echo "Failed to create temporary directory."; exit 1; }
+    if [ "$USE_NIX" ]; then
+        # download, build and install lsfg-vk-flake from GitHub
+        curl -fsSL "$NIX_FLAKE_REPO/archive/refs/tags/$REMOTE_HASH.tar.gz" | tar -xz
 
-    # install lsfg-vk
-    cd "$INSTALL_PATH" || exit 1
-    unzip -o "/tmp/$ZIP_NAME"
+        cd lsfg-vk-flake-* && nix build || { echo "Build failed."; rm -vrf "$TEMP_DIR"; exit 1; }
+
+        install -Dvm644 result/lib/liblsfg-vk.so "$INSTALL_PATH/lib/liblsfg-vk.so"
+        install -Dvm644 result/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json "$INSTALL_PATH/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json"
+    else
+        # download and install prebuilt lsfg-vk
+        curl -fsSL -o "$TEMP_DIR/$ZIP_NAME" "$BASE_URL/$ZIP_NAME" || { echo "Failed to download lsfg-vk. Please check your internet connection."; rm -vrf "$TEMP_DIR"; exit 1; }
+
+        cd "$INSTALL_PATH" && unzip -o "$TEMP_DIR/$ZIP_NAME" || { echo "Extraction failed. Is install path writable or unzip installed?"; rm -vrf "$TEMP_DIR"; exit 1; }
+    fi
+    rm -vrf "$TEMP_DIR"
+
     echo "$REMOTE_HASH" > "$SHA_FILE"
-    rm -v "/tmp/$ZIP_NAME"
 
     echo "lsfg-vk for ${DISTRO_PRETTY} has been installed."
 else

--- a/install.sh
+++ b/install.sh
@@ -74,8 +74,8 @@ else
     echo -n "Do you want to uninstall lsfg-vk? (y/n) "
     read -r uninstall_answer < /dev/tty
     if [ "$uninstall_answer" = "y" ]; then
-        rm -v ~/.local/lib/liblsfg-vk.so
-        rm -v ~/.local/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json
+        rm -v $INSTALL_PATH/lib/liblsfg-vk.so
+        rm -v $INSTALL_PATH/share/vulkan/implicit_layer.d/VkLayer_LS_frame_generation.json
         rm -v "$SHA_FILE"
         echo "Uninstallation completed."
     fi


### PR DESCRIPTION
This adds a Nix option in the installer script that will build the library and copy it into the install path.
It's primarily needed so that it links against the Vulkan library from the Nix store when trying to run lsfg-vk.

Because the flake is being sourced from my repository instead of your file server, I added a note to warn about that in the selector. I'm fine with handing over the flake repository to you or a general lsfg-vk git organization if that's an issue.

The flake_repo variable in its current implementation depends on having a release and I am also using the tags as the remote_hash here which makes it not an accurate variable name, however this had the least resistance in implementing it to keep the same functionality.

For the rest it was just mostly making the script more talkative on relevant failure points which I ran into while adding my own stuff and restructuring it somewhat to try keeping my nix-specific changes contained in larger blocks.