### PR TITLE
Initial frame pacing

### DIFF
--- a/include/context.hpp
+++ b/include/context.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <chrono>
 
 ///
 /// This class is the frame generation context. There should be one instance per swapchain.
@@ -56,6 +57,16 @@ private:
     VkSwapchainKHR swapchain;
     std::vector<VkImage> swapchainImages;
     VkExtent2D extent;
+    std::chrono::high_resolution_clock::time_point previousFrameTimestamp;
+    std::chrono::high_resolution_clock::time_point previousFrameGenTimestamp;
+    
+    // Frame time averaging
+    static constexpr size_t frameTimeHistorySize = 3;
+    std::array<std::chrono::nanoseconds, frameTimeHistorySize> frameTimeHistory = {};
+    size_t frameTimeHistoryIndex = 0;
+    bool frameTimeHistoryFilled = false;
+
+    bool framePacing = false;
 
     std::shared_ptr<int32_t> lsfgCtxId; // lsfg context id
     Mini::Image frame_0, frame_1; // frames shared with lsfg. write to frame_0 when fc % 2 == 0

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -17,6 +17,8 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <chrono>
+#include <thread>
 
 LsContext::LsContext(const Hooks::DeviceInfo& info, VkSwapchainKHR swapchain,
         VkExtent2D extent, const std::vector<VkImage>& swapchainImages)
@@ -38,6 +40,12 @@ LsContext::LsContext(const Hooks::DeviceInfo& info, VkSwapchainKHR swapchain,
     const bool perfMode = lsfgPerfModeStr
         ? *lsfgPerfModeStr == '1'
         : false;
+
+    const char* lsfgFramePacingStr = getenv("LSFG_FRAME_PACING");
+    const bool framePacing = lsfgFramePacingStr
+        ? *lsfgFramePacingStr == '1'
+        : false;
+    this->framePacing = framePacing;
 
     // we could take the format from the swapchain,
     // but honestly this is safer.
@@ -137,7 +145,33 @@ LsContext::LsContext(const Hooks::DeviceInfo& info, VkSwapchainKHR swapchain,
 
 VkResult LsContext::present(const Hooks::DeviceInfo& info, const void* pNext, VkQueue queue,
         const std::vector<VkSemaphore>& gameRenderSemaphores, uint32_t presentIdx) {
+    auto frameTimestamp = this->previousFrameTimestamp;
+    this->previousFrameTimestamp = std::chrono::high_resolution_clock::now();
     auto& pass = this->passInfos.at(this->frameIdx % 8);
+
+    auto frameTime = this->previousFrameTimestamp - frameTimestamp;
+    
+    const auto minFrameTime = std::chrono::nanoseconds(4166667);   // 240 FPS
+    const auto maxFrameTime = std::chrono::nanoseconds(100000000); // 10 FPS
+    frameTime = std::max(minFrameTime, std::min(frameTime, maxFrameTime));
+    
+    this->frameTimeHistory[this->frameTimeHistoryIndex] = frameTime;
+    this->frameTimeHistoryIndex = (this->frameTimeHistoryIndex + 1) % frameTimeHistorySize;
+    if (!this->frameTimeHistoryFilled && this->frameTimeHistoryIndex == 0) {
+        this->frameTimeHistoryFilled = true;
+    }
+    
+    // Calculate average frame time
+    auto averageFrameTime = std::chrono::nanoseconds(0);
+    const size_t historyCount = this->frameTimeHistoryFilled ? frameTimeHistorySize : this->frameTimeHistoryIndex;
+    if (historyCount > 0) {
+        for (size_t i = 0; i < historyCount; ++i) {
+            averageFrameTime += this->frameTimeHistory[i];
+        }
+        averageFrameTime /= historyCount;
+    } else {
+        averageFrameTime = frameTime;
+    }
 
     // 1. copy swapchain image to frame_0/frame_1
     Log::debug("context2", "1. Copying swapchain image {} to frame {}",
@@ -186,6 +220,8 @@ VkResult LsContext::present(const Hooks::DeviceInfo& info, const void* pNext, Vk
     Log::debug("context2",
         "(exiting LSFG present with id: {})", *this->lsfgCtxId);
 
+    const auto averageFrameGenTime = std::chrono::nanoseconds(static_cast<int64_t>(averageFrameTime.count() / (info.frameGen + 1)));
+
     for (size_t i = 0; i < info.frameGen; i++) {
         // 3. acquire next swapchain image
         Log::debug("context2", "3. Acquiring next swapchain image for frame {}", i);
@@ -195,6 +231,23 @@ VkResult LsContext::present(const Hooks::DeviceInfo& info, const void* pNext, Vk
             pass.acquireSemaphores.at(i).handle(), VK_NULL_HANDLE, &imageIdx);
         if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR)
             throw LSFG::vulkan_error(res, "Failed to acquire next swapchain image");
+
+        auto jitter = std::chrono::nanoseconds(0);
+
+        if (i == 0) {
+            auto frameGenTimestamp = std::chrono::high_resolution_clock::now();
+            
+            if (this->frameTimeHistoryFilled && historyCount > 1 && 
+                this->previousFrameGenTimestamp != std::chrono::high_resolution_clock::time_point{}) {
+                
+                jitter = averageFrameTime - (frameGenTimestamp - this->previousFrameGenTimestamp);
+
+                auto radius = averageFrameGenTime;
+                jitter = std::max(-radius, std::min(jitter, radius));
+            }
+
+            this->previousFrameGenTimestamp = frameGenTimestamp;
+        }
 
         // 4. copy output image to swapchain image
         Log::debug("context2", "4. Copying output image to swapchain image for frame {}", i);
@@ -234,6 +287,11 @@ VkResult LsContext::present(const Hooks::DeviceInfo& info, const void* pNext, Vk
         res = Layer::ovkQueuePresentKHR(queue, &presentInfo);
         if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR)
             throw LSFG::vulkan_error(res, "Failed to present swapchain image");
+
+        if (this->framePacing) {
+            Log::debug("context2", "Frame pacing - averageFrameGenTime {:.3f}ms, jitter {:.3f}ms", averageFrameGenTime.count() / 1000000.0, jitter.count() / 1000000.0);
+            std::this_thread::sleep_for(averageFrameGenTime - jitter);
+        }
     }
 
     // 6. present actual next frame
@@ -252,6 +310,6 @@ VkResult LsContext::present(const Hooks::DeviceInfo& info, const void* pNext, Vk
     if (res != VK_SUCCESS && res != VK_SUBOPTIMAL_KHR)
         throw LSFG::vulkan_error(res, "Failed to present swapchain image");
 
-    this->frameIdx++;
+    this->frameIdx++;    
     return res;
 }


### PR DESCRIPTION
This patch adds frame pacing between each generated frame. It helps in some, but not all, situations.

The idea is that the patch:
* Discovers what the average base frame rate is
* Divides that average by the total number of frames to render in that interval to get a target generated frame interval
* The generated frames are then delayed by the target generated frame interval, hoping to evenly space all the frames apart.

The is additionally some "jitter" detection, hoping to smooth out base frames that may come in slightly late or early.

This can be enabled with `LSFG_FRAME_PACING=1`.