### PR TITLE
fix decorations and icon issues with AppImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         packages: git wget xvfb
           clang clang-tools llvm rustup
           cmake ninja-build pkg-config
-          libdecor-0 libvulkan-dev
+          libdecor-0-0 libvulkan-dev
           libgtk-4-dev libadwaita-1-dev
         version: 1.0
         execute_install_scripts: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         packages: git wget xvfb
           clang clang-tools llvm rustup
           cmake ninja-build pkg-config
-          libvulkan-dev
+          libdecor-0 libvulkan-dev
           libgtk-4-dev libadwaita-1-dev
         version: 1.0
         execute_install_scripts: true

--- a/scripts/build/appimage.sh
+++ b/scripts/build/appimage.sh
@@ -48,8 +48,9 @@ mv -v target/release/lsfg-vk-ui AppDir/shared/bin
 cd AppDir
     xvfb-run -a ../sharun-aio l -p -v -e -s -k \
         shared/bin/lsfg-vk-ui \
-        /usr/lib/gdk-pixbuf-*/*/loaders/* \
-        /usr/lib/gio/modules/libdconfsettings.so
+        /usr/lib/*/libdecor* \
+        /usr/lib/*/gdk-pixbuf-*/*/loaders/* \
+        /usr/lib/*/gio/modules/libdconfsettings.so
     ln -fv ./sharun ./AppRun
     ./sharun -g
 cd ..


### PR DESCRIPTION
Turns out `libdconfsettings.so` and the gdk plugins were not being added because the original path given to sharun was `/usr/lib/*`

but since the script is being used in ubuntu, this has the extra `x86_64-linux-gnu` dir in the middle. 

This fixes issues with the minimize/maximize buttons not showing as well as some issues with the process picker icon not showing on some systems. 