### PR TITLE
Fix __attribute__ position in layer.hpp

### DIFF
--- a/include/layer.hpp
+++ b/include/layer.hpp
@@ -219,8 +219,8 @@ namespace Layer {
 }
 
 /// Symbol definition for Vulkan instance layer.
-__attribute__((visibility("default")))
-extern "C" PFN_vkVoidFunction layer_vkGetInstanceProcAddr(VkInstance instance, const char* pName);
+extern "C" __attribute__((visibility("default")))
+PFN_vkVoidFunction layer_vkGetInstanceProcAddr(VkInstance instance, const char* pName);
 /// Symbol definition for Vulkan device layer.
-__attribute__((visibility("default")))
-extern "C" PFN_vkVoidFunction layer_vkGetDeviceProcAddr(VkDevice device, const char* pName);
+extern "C" __attribute__((visibility("default")))
+PFN_vkVoidFunction layer_vkGetDeviceProcAddr(VkDevice device, const char* pName);


### PR DESCRIPTION
GCC was ignoring it because of the position (you can see warnings about it in the logs when building lsfg-vk), so I got `[Vulkan Loader] ERROR | LAYER:  loader_create_device_chain: Failed to find 'vkGetInstanceProcAddr' in layer "liblsfg-vk.so".  Skippinglayer.` at runtime on my machine

This fixes it