### PR TITLE
fix: ui: create config directory before config file

### DIFF
--- a/lsfg-vk-ui/src/backend.cpp
+++ b/lsfg-vk-ui/src/backend.cpp
@@ -71,6 +71,9 @@ Backend::Backend() {
             config.profiles() = this->m_profiles;
 
             try {
+                std::filesystem::create_directories(path.parent_path());
+                if (!std::filesystem::exists(path.parent_path()))
+                    throw ls::error("unable to create configuration directory");
                 config.write(path);
             } catch (const std::exception& e) {
                 std::cerr << "unable to write configuration:\n- " << e.what() << "\n";


### PR DESCRIPTION
If `lsfg-vk-ui` is ran before the default configuration file has been created and `~/.config/lsfg-vk` didn't already exist it'll fail to write any changes to the defaults because of the missing configuration directory.

A small fix that copies the same logic from `createDefaultConfigFile(...)`